### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
         branches: [ main ]
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     check-cs:
         name: Coding Style


### PR DESCRIPTION
Potential fix for [https://github.com/qdequippe-tech/pappers-php-api/security/code-scanning/6](https://github.com/qdequippe-tech/pappers-php-api/security/code-scanning/6)

In general, the fix is to explicitly set GitHub Actions `permissions` to the minimal required level instead of inheriting repository defaults. This can be done either at the workflow root (affecting all jobs) or per job. Here, there is a single job (`check-cs`) that only reads code, so we can safely restrict contents to read-only.

The best minimal fix without changing behavior is to add a `permissions` block at the workflow root, right after the `on:` block and before `jobs:`. We will set `contents: read`, which is sufficient for `actions/checkout` to fetch the repository content. No other scopes (like `pull-requests` or `issues`) are needed because the workflow does not interact with those APIs. Concretely, in `.github/workflows/ci.yml`, we’ll insert:

```yaml
permissions:
    contents: read
```

aligned with the existing indentation so that it applies to all jobs in the workflow. No imports or additional methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
