### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/diff-spec.yml
+++ b/.github/workflows/diff-spec.yml
@@ -9,6 +9,9 @@ jobs:
     check-spec:
         name: Check SDK is in sync with spec
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/qdequippe-tech/pappers-php-api/security/code-scanning/5](https://github.com/qdequippe-tech/pappers-php-api/security/code-scanning/5)

In general, the fix is to explicitly scope the `GITHUB_TOKEN` permissions in this workflow to the minimal set needed. That can be done either at the workflow root (applies to all jobs) or per job. Since there is only a single `check-spec` job, adding a `permissions` block under that job is clear and sufficient.

The `peter-evans/create-pull-request` action needs to push commits and open/update PRs, which requires `contents: write` and `pull-requests: write`. The earlier steps (checkout, composer, code generation, rector, php-cs-fixer) only read and modify the local filesystem and do not require GitHub API permissions beyond what `actions/checkout` already uses via the same token; `contents: write` is already implied by the need to push changes, so there is no additional expansion of privilege beyond what is functionally required. The best minimal configuration therefore is:

```yaml
permissions:
  contents: write
  pull-requests: write
```

This should be added under `jobs.check-spec` (e.g., between `runs-on:` and `steps:`) in `.github/workflows/diff-spec.yml`. No imports or additional methods are needed since this is a YAML workflow file and permissions are a first-class configuration key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
